### PR TITLE
Support jsx grammar

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -44,6 +44,7 @@ class CompletionProvider {
     let testRegex;
     switch (languageScope) {
       case 'source.js':
+      case 'source.js.jsx':
         testRegex = /require|import/;
         break;
       case 'source.css':


### PR DESCRIPTION
* jsx also uses require and import, so use existing js test regex with js.jsx grammar