### PR TITLE
Add grammars for jsx and es6

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -11,7 +11,10 @@ const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|
 
 class CompletionProvider {
   constructor() {
-    this.selector = '.source.js .string.quoted, .source.coffee .string.quoted';
+    this.selector = '.source.js .string.quoted' +
+      ', .source.coffee .string.quoted' +
+      ', .source.js.jsx .string.quoted' +
+      ', .source.js.es6 .string.quoted';
     this.disableForSelector = '.source.js .comment, source.js .keyword';
     this.inclusionPriority = 1;
   }


### PR DESCRIPTION
* Add grammars `.source.js.jsx` and `source.js.es6`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nkt/atom-autocomplete-modules/20)
<!-- Reviewable:end -->
