### PR TITLE
Custom paths

### DIFF
--- a/.tern-project
+++ b/.tern-project
@@ -1,8 +1,7 @@
 {
+  "ecmaVersion": 6,
   "libs": [
     "browser",
-    "ecma5",
-    "ecma6",
     "jquery"
   ],
   "plugins": {

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Autocomplete for require/import statements.
 
 ![Preview](https://cloud.githubusercontent.com/assets/3505878/7442538/9c1892cc-f11e-11e4-8070-3fa8b79beefc.gif)
 
+## Configuration
+
+**Vendor directories:** A list of directories to search for modules relative to the project
+  root. (*Default:* `node_modules`)
+
 License
 -------
 [![MIT License](https://img.shields.io/apm/l/autocomplete-modules.svg)](LICENSE)

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -84,7 +84,11 @@ class CompletionProvider {
   }
 
   lookupGlobal(prefix, vendor = 'node_modules') {
-    const projectPath = atom.project.getPaths()[0] || [];
+    const projectPath = atom.project.getPaths()[0];
+    if (!projectPath) {
+      return Promise.resolve([]);
+    }
+
     const vendorPath = path.join(projectPath, vendor);
 
     if (prefix.indexOf('/') !== -1) {

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -90,7 +90,6 @@ class CompletionProvider {
     if (prefix.indexOf('/') !== -1) {
       return this.lookupLocal(`./${prefix}`, vendorPath);
     }
-    console.log('!!!', prefix, vendorPath);
 
     return readdir(vendorPath).then((libs) => {
       return libs.concat(internalModules);

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,18 @@
 const CompletionProvider = require('./completion-provider');
 
 class AutocompleteModulesPlugin {
+  constructor() {
+    this.config = {
+      vendors: {
+        type: 'array',
+        default: ['node_modules'],
+        items: {
+          type: 'string'
+        }
+      }
+    };
+  }
+
   activate() {
     this.completionProvider = new CompletionProvider();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ class AutocompleteModulesPlugin {
   constructor() {
     this.config = {
       vendors: {
+        title: 'Vendor directories',
+        description: 'A list of directories to search for modules relative to the project root.',
         type: 'array',
         default: ['node_modules'],
         items: {


### PR DESCRIPTION
This is a rough fix for #3 . It takes a list of module dirs relative to the project root and searches any of the listed paths. Potentially this could be extended to support scanning for webpack or bower config files and pulling the vendor paths out of there. I'm currently working on that option for webpack but this gets the basic needs met here. Using the Project Manager package allows you to create a custom list of vendor directories per project.