### PR TITLE
Webpack support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Autocomplete for require/import statements.
 **Vendor directories:** A list of directories to search for modules relative to the project
   root. (*Default:* `node_modules`)
 
+**Webpack support:** Look for webpack configuration file and add the `resolve.modulesDirectories` paths to the module search scope.
+
+**Webpack configuration filename:** Name of the configuration file to look for. (*Default:* `webpack.config.js`)
+
 License
 -------
 [![MIT License](https://img.shields.io/apm/l/autocomplete-modules.svg)](LICENSE)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "bluebird": "3.3.1",
     "fuzzaldrin": "2.1.0",
-    "lodash.escaperegexp": "4.1.0"
+    "lodash.escaperegexp": "4.1.0",
+    "lodash.get": "4.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.8",

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -123,13 +123,10 @@ class CompletionProvider {
       return Promise.resolve([]);
     }
 
-    const webpackConfigFilename = atom.config.get('autocomplete-modules.webpackConfigFilename');
-    const webpackConfigPath = path.join(projectPath, webpackConfigFilename);
     const vendors = atom.config.get('autocomplete-modules.vendors');
+    const webpackConfig = this.fetchWebpackConfig(projectPath);
 
-    const webpackConfig = require(webpackConfigPath);
     let moduleSearchPaths = get(webpackConfig, 'resolve.modulesDirectories', []);
-
     moduleSearchPaths = moduleSearchPaths.filter(
       (item) => vendors.indexOf(item) === -1
     );
@@ -137,6 +134,17 @@ class CompletionProvider {
     return Promise.all(moduleSearchPaths.map(
       (searchPath) => this.lookupLocal(prefix, searchPath)
     )).then((suggestions) => [].concat(...suggestions));
+  }
+
+  fetchWebpackConfig(rootPath) {
+    const webpackConfigFilename = atom.config.get('autocomplete-modules.webpackConfigFilename');
+    const webpackConfigPath = path.join(rootPath, webpackConfigFilename);
+
+    try {
+      return require(webpackConfigPath);
+    } catch (error) {
+      return {};
+    }
   }
 }
 

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -5,6 +5,7 @@ const readdir = Promise.promisify(require('fs').readdir);
 const path = require('path');
 const fuzzaldrin = require('fuzzaldrin');
 const escapeRegExp = require('lodash.escaperegexp');
+const get = require('lodash.get');
 const internalModules = require('./internal-modules');
 
 const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|}\s*from\s*['"]/;
@@ -127,7 +128,7 @@ class CompletionProvider {
     const vendors = atom.config.get('autocomplete-modules.vendors');
 
     const webpackConfig = require(webpackConfigPath);
-    let moduleSearchPaths = webpackConfig.resolve.modulesDirectories;
+    let moduleSearchPaths = get(webpackConfig, 'resolve.modulesDirectories', []);
 
     moduleSearchPaths = moduleSearchPaths.filter(
       (item) => vendors.indexOf(item) === -1

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,18 @@ class AutocompleteModulesPlugin {
         items: {
           type: 'string'
         }
+      },
+      webpack: {
+        title: 'Webpack support',
+        description: 'Attempts to use the given webpack configuration file resolution settings to search for modules.',
+        type: 'boolean',
+        default: false
+      },
+      webpackConfigFilename: {
+        title: 'Webpack configuration filename',
+        description: 'When "Webpack support" is enabled this is the config file used to supply module search paths.',
+        type: 'string',
+        default: 'webpack.config.js'
       }
     };
   }


### PR DESCRIPTION
Building upon #22, I added configuration for supporting webpack module resolution. This does not add aliases or other complex features although it could potentially be expanded to do that. It simply adds the list of paths found in `resolve.modulesDirectories` to the search scope ***minus*** the already existing directories in the `vendors` config value provided in #22.

As a bonus I have included a simple [editorconfig](http://editorconfig.org/) file to help other contributors.