### PR TITLE
prevent webpack config from loading from node module cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "bluebird": "3.3.1",
     "fuzzaldrin": "2.1.0",
     "lodash.escaperegexp": "4.1.0",
-    "lodash.get": "4.1.0"
+    "lodash.get": "4.1.0",
+    "require-new": "^1.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.8",

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -7,6 +7,7 @@ const fuzzaldrin = require('fuzzaldrin');
 const escapeRegExp = require('lodash.escaperegexp');
 const get = require('lodash.get');
 const internalModules = require('./internal-modules');
+const requireNew = require('require-new');
 
 const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|}\s*from\s*['"]/;
 
@@ -141,7 +142,7 @@ class CompletionProvider {
     const webpackConfigPath = path.join(rootPath, webpackConfigFilename);
 
     try {
-      return require(webpackConfigPath);
+      return requireNew(webpackConfigPath);
     } catch (error) {
       return {};
     }


### PR DESCRIPTION
The [`require-new`](https://www.npmjs.com/package/require-new) module prevents the webpack config from being cached. There could be a performance hit if a user's webpack config is complex but that risk is low. Perhaps there should be a warning in the package settings with the enabling checkbox? Or maybe the user should have the responsibility to be aware of the implications of enabling support for this? I feel like there should be more error handling and notification. Right now errors are caught and allowed to silently fail. I'll look into adding a toast notification in the catch blocks later. I'm open to any thoughts on this.
