### PR TITLE
Add string boundaries to autocomplete selectors (fixes #28).

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -12,7 +12,7 @@ const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|
 
 class CompletionProvider {
   constructor() {
-    this.selector = '.source.js .string.quoted, .source.coffee .string.quoted';
+    this.selector = '.source.js .string.quoted, .source.js .punctuation.definition.string.begin, .source.coffee .string.quoted';
     this.disableForSelector = '.source.js .comment, source.js .keyword';
     this.inclusionPriority = 1;
   }


### PR DESCRIPTION
This works around the autocomplete provider's tendency to assume, when using the `language-babel` package, that when the caret is adjacent to a closing quotation mark its active scope is `punctuation.definition.string.begin`.