### PR TITLE
Match named exports.

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -8,7 +8,7 @@ const escapeRegExp = require('lodash.escaperegexp');
 const get = require('lodash.get');
 const internalModules = require('./internal-modules');
 
-const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|}\s*from\s*['"]/;
+const LINE_REGEXP = /require|import|export\s+(?:\*|{?[a-zA-Z0-9_$,\s]+}?)+\s+from|}\s*from\s*['"]/;
 const SELECTOR = [
   '.source.js .string.quoted',
   // for babel-language plugin


### PR DESCRIPTION
Allow the ES6-style `export Foo from './bar'` syntax when matching lines.