### PR TITLE
Add support for Babel Plugin Module Alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Autocomplete for require/import statements.
 
 **Webpack configuration filename:** Name of the configuration file to look for. (*Default:* `webpack.config.js`)
 
+**Babel Plugin Module Alias support:** Look for a [Babel Plugin Module Alias](https://github.com/tleunen/babel-plugin-module-alias) configuration and use it for the autocomplete suggestions.
+
 License
 -------
 [![MIT License](https://img.shields.io/apm/l/autocomplete-modules.svg)](LICENSE)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "bluebird": "3.4.0",
+    "find-babel-config": "^0.1.1",
     "fuzzaldrin": "2.1.0",
     "lodash.escaperegexp": "4.1.1",
     "lodash.get": "4.3.0"

--- a/src/main.js
+++ b/src/main.js
@@ -6,12 +6,14 @@ class AutocompleteModulesPlugin {
   constructor() {
     this.config = {
       includeExtension: {
+        order: 1,
         title: 'Include file extension',
         description: "Include the file's extension when filling in the completion.",
         type: 'boolean',
         default: false
       },
       vendors: {
+        order: 2,
         title: 'Vendor directories',
         description: 'A list of directories to search for modules relative to the project root.',
         type: 'array',
@@ -21,16 +23,25 @@ class AutocompleteModulesPlugin {
         }
       },
       webpack: {
+        order: 3,
         title: 'Webpack support',
         description: 'Attempts to use the given webpack configuration file resolution settings to search for modules.',
         type: 'boolean',
         default: false
       },
       webpackConfigFilename: {
+        order: 4,
         title: 'Webpack configuration filename',
         description: 'When "Webpack support" is enabled this is the config file used to supply module search paths.',
         type: 'string',
         default: 'webpack.config.js'
+      },
+      babelPluginModuleAlias: {
+        order: 5,
+        title: 'Babel Plugin Module Alias support',
+        description: 'Use the <a href="https://github.com/tleunen/babel-plugin-module-alias">Babel Plugin Module Alias</a> configuration located in your `.babelrc` or in the babel configuration in `package.json`.',
+        type: 'boolean',
+        default: false
       }
     };
   }


### PR DESCRIPTION
Fix #40.

This adds the support for the [Module Alias](https://github.com/tleunen/babel-plugin-module-alias) plugin for Babel.

Tested locally on a project using the plugin and everything works fine.
Tested with direct files, directories and even sub sub sub directories.