### PR TITLE
Update for async findBabelConfig + add support for babel-plugin-module-resolver v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Autocomplete for require/import statements.
 
 **Webpack configuration filename:** Name of the configuration file to look for. (*Default:* `webpack.config.js`)
 
-**Babel Plugin Module Alias support:** Look for a [Babel Plugin Module Alias](https://github.com/tleunen/babel-plugin-module-alias) configuration and use it for the autocomplete suggestions.
+**Babel Plugin Module Resolver support:** Look for a [Babel Plugin Module Resolver](https://github.com/tleunen/babel-plugin-module-resolver) configuration and use it for the autocomplete suggestions.
 
 License
 -------

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bluebird": "3.4.0",
-    "find-babel-config": "^0.1.1",
+    "find-babel-config": "^1.0.0",
     "fuzzaldrin": "2.1.0",
     "lodash.escaperegexp": "4.1.1",
     "lodash.get": "4.3.0"

--- a/src/main.js
+++ b/src/main.js
@@ -36,10 +36,10 @@ class AutocompleteModulesPlugin {
         type: 'string',
         default: 'webpack.config.js'
       },
-      babelPluginModuleAlias: {
+      babelPluginModuleResolver: {
         order: 5,
-        title: 'Babel Plugin Module Alias support',
-        description: 'Use the <a href="https://github.com/tleunen/babel-plugin-module-alias">Babel Plugin Module Alias</a> configuration located in your `.babelrc` or in the babel configuration in `package.json`.',
+        title: 'Babel Plugin Module Resolver support',
+        description: 'Use the <a href="https://github.com/tleunen/babel-plugin-module-resolver">Babel Plugin Module Resolver</a> configuration located in your `.babelrc` or in the babel configuration in `package.json`.',
         type: 'boolean',
         default: false
       }


### PR DESCRIPTION
hey @nkt, sorry for the long long delay with this... But I finally updated the code to use the async version of `find-babel-config`, as you requested in #41.

Also, I update my initial plugin (and change its name) so I updated the code for the auto complete. Both cases are handled.

The code is pretty much the same, only a specific case to handle `root` from the plugin was really added.

Thanks :)