### PR TITLE
Fix current project dir lookup

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -48,8 +48,9 @@ class CompletionProvider {
 
     const vendors = atom.config.get('autocomplete-modules.vendors');
 
+    const currentFilePath = editor.buffer.file.path;
     const promises = vendors.map(
-      (vendor) => this.lookupGlobal(realPrefix, vendor)
+      (vendor) => this.lookupGlobal(realPrefix, currentFilePath, vendor)
     );
 
     const webpack = atom.config.get('autocomplete-modules.webpack');
@@ -120,8 +121,8 @@ class CompletionProvider {
     return filename.replace(/\.(js|es6|jsx|coffee|ts|tsx)$/, '');
   }
 
-  lookupGlobal(prefix, vendor = 'node_modules') {
-    const projectPath = atom.project.getPaths()[0];
+  lookupGlobal(prefix, currentFilePath, vendor = 'node_modules') {
+    const [projectPath] = atom.project.relativizePath(currentFilePath);
     if (!projectPath) {
       return Promise.resolve([]);
     }


### PR DESCRIPTION
- Find current project based on current filename

See also:
https://discuss.atom.io/t/project-folder-path-of-opened-file/24846/14
## Testing
1. Open multiple node projects in atom (with different deps/node_modules)
2. Edit a file in any but the first project in tree view
3. Trigger module autocomplete

Before patch:

Observe that the modules listed come from the first project in tree view, rather than the project to which the file belongs.

(can be checked in dev tools as well)

After patch:

Check that the modules listed come from the project to which the file belongs

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nkt/atom-autocomplete-modules/46)

<!-- Reviewable:end -->
