### PR TITLE
Add ability to use webpack root feature if it exists in config

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -159,13 +159,14 @@ class CompletionProvider {
     const vendors = atom.config.get('autocomplete-modules.vendors');
     const webpackConfig = this.fetchWebpackConfig(projectPath);
 
+    const webpackRoot = get(webpackConfig, 'resolve.root', '');
     let moduleSearchPaths = get(webpackConfig, 'resolve.modulesDirectories', []);
     moduleSearchPaths = moduleSearchPaths.filter(
       (item) => vendors.indexOf(item) === -1
     );
 
     return Promise.all(moduleSearchPaths.map(
-      (searchPath) => this.lookupLocal(prefix, searchPath)
+      (searchPath) => this.lookupLocal(prefix, path.join(webpackRoot, searchPath))
     )).then(
       (suggestions) => [].concat(...suggestions)
     );


### PR DESCRIPTION
In our project we use the `root` field in the webpack config so the current plugin does not find our packages. Adding the lookup fixes it. Below is what the resolve object looks like with the `root` field.

```javascript
resolve: {
  root: webModules, // path to our src dir
  modulesDirectories: [
    'node_modules',
    'js'
  ],
  extensions: ['', '.js']
}
```

I have tested this change works in both cases.