### PR TITLE
Revert "Match named exports."

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -9,7 +9,7 @@ const get = require('lodash.get');
 const findBabelConfig = require('find-babel-config');
 const internalModules = require('./utils/internal-modules');
 
-const LINE_REGEXP = /require|import|export\s+(?:\*|{?[a-zA-Z0-9_$,\s]+}?)+\s+from|}\s*from\s*['"]/;
+const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|}\s*from\s*['"]/;
 const SELECTOR = [
   '.source.js .string.quoted',
 


### PR DESCRIPTION
I have to revert this, cause #49 issue.
I'm working on v2.0, I'll try to reimplement this functionality in next release.