### PR TITLE
Take another crack at matching named exports.

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -9,7 +9,7 @@ const get = require('lodash.get');
 const findBabelConfig = require('find-babel-config');
 const internalModules = require('./utils/internal-modules');
 
-const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+})+\s+from|}\s*from\s*['"]/;
+const LINE_REGEXP = /require|import|export\s+(?:\*|{[a-zA-Z0-9_$,\s]+}|[a-zA-Z0-0_$]+)+\s+from|}\s*from\s*['"]/;
 const SELECTOR = [
   '.source.js .string.quoted',
 


### PR DESCRIPTION
I gather from #59 that my previous change to the regex was too general and sent Atom into a matching frenzy that pegged folks' CPUs. Mea culpa! I thought I'd take another crack at it with a much less broad pattern. I haven't seen any memory or processor issues locally, but of course it bears testing on other devices.