### PR TITLE
Bugfix/webpack resolve root

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -92,7 +92,7 @@ class CompletionProvider {
 
   lookupLocal(prefix, dirname) {
     let filterPrefix = prefix.replace(path.dirname(prefix), '').replace('/', '');
-    if (filterPrefix[filterPrefix.length - 1] === '/') {
+    if (prefix[prefix.length - 1] === '/') {
       filterPrefix = '';
     }
 

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -166,8 +166,8 @@ class CompletionProvider {
       (item) => vendors.indexOf(item) === -1
     );
 
-    return Promise.all(moduleSearchPaths.map(
-      (searchPath) => this.lookupLocal(prefix, path.join(webpackRoot, searchPath))
+    return Promise.all(moduleSearchPaths.concat(webpackRoot).map(
+      (searchPath) => this.lookupLocal(prefix, path.join(projectPath, searchPath))
     )).then(
       (suggestions) => [].concat(...suggestions)
     );


### PR DESCRIPTION
Mainly fixing #50 ("TypeError: Path must be a string.").
As a side effect this also fixes `resolve.modulesDirectories` not having any effect.
Also while at it, I fixed an issue with the autocompletion on paths like `../`, `../../` and `lib/` (when `lib` is a child of a `resolve.root` dir). Let me know if this should go in a separate PR.