### PR TITLE
Add activation hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,13 @@
         "2.0.0": "getCompletionProvider"
       }
     }
-  }
+  },
+  "activationHooks": [
+    "language-javascript:grammar-used",
+    "language-babel:grammar-used",
+    "language-coffee-script:grammar-used",
+    "language-ts:grammar-used",
+    "language-typescript-grammars-only:grammar-used",
+    "atom-typescript:grammar-used"
+  ]
 }


### PR DESCRIPTION
This delays the activation of the package until the user opens a JS, TS or coffee script file and thereby reduces Atoms startup time.
For this package this is actually quite important, since it takes a relative long time to activate it (800-1100ms in my case, you can see this in the Timecop view).

I added all the packages that define the grammars used in [the selectors of the auto complete provider](https://github.com/nkt/atom-autocomplete-modules/blob/master/src/completion-provider.js#L13).