### PR TITLE
Support nested .babelrc

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -206,8 +206,14 @@ class CompletionProvider {
 
   lookupbabelPluginModuleResolver(prefix, activePanePath) {
     const projectPath = this.getProjectPath(activePanePath);
-    if (projectPath) {
-      return findBabelConfig(projectPath).then(({config}) => {
+
+    if (!projectPath) return;
+
+    const suggestionsTotal = [];
+    let currentPath = path.dirname(activePanePath);
+
+    while (currentPath.startsWith(projectPath)) {
+      const currentSuggestions = findBabelConfig(currentPath).then(({config}) => {
         if (config && Array.isArray(config.plugins)) {
           // Grab the v1 (module-alias) or v2 (module-resolver) plugin configuration
           const pluginConfig = config.plugins.find(p => p[0] === 'module-alias' || p[0] === 'babel-plugin-module-alias') ||
@@ -274,7 +280,14 @@ class CompletionProvider {
 
         return [];
       });
+
+      suggestionsTotal.push(currentSuggestions);
+      currentPath = path.resolve(currentPath, '../');
     }
+
+    return Promise
+      .all(suggestionsTotal)
+      .then(list => list.reduce((acc, suggestions) => acc.concat(suggestions), []));
   }
 }
 


### PR DESCRIPTION
Thanks a lot for this package!

It'd be great to support searching nested `.babelrc` configs too, because some projects has different resolving strategies in subfolders.

And I think that it also should resolve https://github.com/nkt/atom-autocomplete-modules/issues/57
