### PR TITLE
:heavy_minus_sign: Remove unused dep by esm-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,11 @@
   },
   "dependencies": {
     "bluebird": "3.5.1",
-    "esm-exports": "0.8.4",
+    "esm-exports": "^0.8.4",
     "find-babel-config": "1.1.0",
     "fuzzaldrin": "2.1.0",
     "lodash.escaperegexp": "4.1.2",
-    "lodash.get": "4.4.2",
-    "resolve": "1.5.0"
+    "lodash.get": "4.4.2"
   },
   "devDependencies": {
     "eslint": "3.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,10 +615,6 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -689,12 +685,6 @@ resolve-pkg@^1.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pkg/-/resolve-pkg-1.0.0.tgz#e19a15e78aca2e124461dc92b2e3943ef93494d9"
   dependencies:
     resolve-from "^2.0.0"
-
-resolve@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
-  dependencies:
-    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Removes the resolve package that was obsolete in esm-exports package but was expected in the code: see https://github.com/unlight/esm-exports/issues/8.
