### PR TITLE
:bug: Strip curly bracers from prefix

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -35,6 +35,9 @@ class CompletionProvider {
   }
 
   getSuggestions({editor, bufferPosition, prefix}) {
+    //NOTE: Workaround for autocomplete issue -> https://github.com/atom/autocomplete-plus/issues/855
+    prefix = prefix.trim().replace(/{|}/,'');
+
     const line = editor.buffer.lineForRow(bufferPosition.row);
     if (!LINE_REGEXP.test(line)) {
       return [];


### PR DESCRIPTION
mainly to workaround https://github.com/atom/autocomplete-plus/issues/855.
This will need to be reverted when that issues is fixed.