### PR TITLE
Implement looking up webpack aliases

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -192,6 +192,7 @@ class CompletionProvider {
 
     // Webpack v2
     const webpackModules = get(webpackConfig, 'resolve.modules', []);
+    const webpackAliases = get(webpackConfig, 'resolve.alias', {});
 
     // Webpack v1
     const webpackRoot = get(webpackConfig, 'resolve.root', '');
@@ -205,9 +206,51 @@ class CompletionProvider {
         prefix,
         path.isAbsolute(searchPath) ? searchPath : path.join(projectPath, searchPath)
       )
+    ).concat(
+      this.lookupAliases(prefix, projectPath, Object.keys(webpackAliases).map(exp => ({
+        expose: exp,
+        src: webpackAliases[exp]
+      })))
     )).then(
       (suggestions) => [].concat(...suggestions)
     );
+  }
+
+  lookupAliases(prefix, projectPath, aliases = {}) {
+    // determine the right prefix for the alias config
+    // `realPrefix` is the prefix we want to use to find the right file/suggestions
+    // when the prefix is a sub module (eg. module/subfile),
+    // `modulePrefix` will be "module", and `realPrefix` will be "subfile"
+    const prefixSplit = prefix.split('/');
+    const modulePrefix = prefixSplit[0];
+    const realPrefix = prefixSplit.pop();
+    const moduleSearchPath = prefixSplit.join('/');
+
+    return Promise.all(aliases
+      .filter(alias => alias.expose.startsWith(modulePrefix))
+      .map(
+      (alias) => {
+        // The search path is the source directory specified in .babelrc
+        // then we append the `moduleSearchPath` (without the alias)
+        // to get the real search path
+        const searchPath = path.join(
+          path.resolve(projectPath, alias.src),
+          moduleSearchPath.replace(alias.expose, '')
+        );
+
+        return this.lookupLocal(realPrefix, searchPath);
+      }
+    )).then(
+      (suggestions) => [].concat(...suggestions)
+    ).then(suggestions => {
+      // make sure the suggestions are from the compatible alias
+      if (prefix === realPrefix && aliases.length) {
+        return suggestions.filter(sugg =>
+          aliases.find(a => a.expose === sugg.text)
+        );
+      }
+      return suggestions;
+    });
   }
 
   fetchWebpackConfig(rootPath) {


### PR DESCRIPTION
Fixes #25 
Very much WIP - I've just copied the code from eslint aliases. Definitely scope for merging code there.

Also, it only seems to work in terms of suggesting items within webpack aliases - it won't suggest the top level alias. Not looked into it too much yet.

Feel free to tidy up the duplicated code.