### PR TITLE
Bugfix/es6 import basic modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bluebird": "3.5.1",
-    "esm-exports": "^0.8.4",
+    "esm-exports": "^2.0.3",
     "find-babel-config": "1.1.0",
     "fuzzaldrin": "2.1.0",
     "lodash.escaperegexp": "4.1.2",

--- a/src/utils/export-module-completion.js
+++ b/src/utils/export-module-completion.js
@@ -56,9 +56,16 @@ const lookupGlobal = (importModule, activePanePath) => {
 };
 
 const getMainFileName = (nodeModulePath) => {
-  const content = fs.readFileSync(path.resolve(nodeModulePath, 'package.json'), {encoding: 'utf8'});
-  const mainFile = JSON.parse(content).main || 'index';
-  return mainFile.substring(0, mainFile.lastIndexOf('.'));
+  let mainFile;
+  try {
+    const content = fs.readFileSync(path.resolve(nodeModulePath, 'package.json'), {encoding: 'utf8'});
+    mainFile = JSON.parse(content).main || 'index';
+  }
+  catch(_e) {
+    // if failed it must not a package root but a file.
+    return path.resolve(`${nodeModulePath}.js`);
+  }
+  return `${mainFile.substring(0, mainFile.lastIndexOf('.'))}.js`;
 };
 
 const getProjectPath = (activePanePath) => {
@@ -71,15 +78,17 @@ const lookupLocal  = (importModule, activePanePath) => {
   return parseFile(importModule, {basedir: filePath})
     .then(results => results.length > 0 ?
       results.map(entry => entry.name) :
-      lookupCommonJs(importModule, filePath))
+      lookupCommonJs(`${importModule}.js`, filePath))
     .catch(() => {
-      return lookupCommonJs(importModule, filePath);
+      return lookupCommonJs(`${importModule}.js`, filePath);
     });
 };
 
-const lookupCommonJs = (importModule, projectPath) => {
-  const absoluteFile = path.resolve(projectPath, `${importModule}.js`);
-  return Object.keys(require(path.normalize(absoluteFile)));
+const lookupCommonJs = (importFile, projectPath) => {
+  const absoluteFile = path.resolve(projectPath, importFile);
+  const importedObj = require(path.normalize(absoluteFile));
+  return (typeof importedObj === "object") ? Object.keys(importedObj)
+    : (typeof importedObj === "function") ? [importedObj.name] : [importedObj];
 }
 
 module.exports = {

--- a/src/utils/export-module-completion.js
+++ b/src/utils/export-module-completion.js
@@ -6,7 +6,8 @@ const fs = require('fs');
 const PATH_SLASH = process.platform === 'win32' ? '\\' : '/';
 
 const escapeRegExp = require('lodash.escaperegexp');
-const { parseModule, parseFile } = require('esm-exports');
+const parseModule = require('esm-exports').module;
+const parseFile = require('esm-exports').file;
 
 const getRealExportPrefix = (prefix, line) => {
   try {
@@ -43,7 +44,7 @@ const getExports = (activePanePath, prefix, importModule) => {
 
 const lookupGlobal = (importModule, activePanePath) => {
   const projectPath = getProjectPath(activePanePath);
-  return parseModule(importModule, {dirname: projectPath})
+  return parseModule(importModule, {basedir: projectPath})
     .then(results => {
       if (results.length > 0) {
         return results.map(entry => entry.name);
@@ -67,7 +68,7 @@ const getProjectPath = (activePanePath) => {
 
 const lookupLocal  = (importModule, activePanePath) => {
   const filePath = activePanePath.substring(0, activePanePath.lastIndexOf(PATH_SLASH));
-  return parseFile(importModule, {dirname: filePath})
+  return parseFile(importModule, {basedir: filePath})
     .then(results => results.length > 0 ?
       results.map(entry => entry.name) :
       lookupCommonJs(importModule, filePath))

--- a/yarn.lock
+++ b/yarn.lock
@@ -274,14 +274,14 @@ eslint@3.6.1:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-esm-exports@0.8.4:
-  version "0.8.4"
-  resolved "https://registry.npmjs.org/esm-exports/-/esm-exports-0.8.4.tgz#1fee79152f5de28a5154dd80628c545f1b1939c5"
+esm-exports@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esm-exports/-/esm-exports-2.0.3.tgz#d5d7fa7174bbf588d1be251680ceea1bdbefb1ca"
   dependencies:
-    lodash "^4.17.4"
-    njct "^1.0.0"
-    resolve-pkg "^1.0.0"
-    typescript "^2.6.1"
+    object-values "^1.0.0"
+    resolve "^1.5.0"
+    tslib "^1.8.1"
+    typescript "^2.6.2"
 
 espree@^3.3.1:
   version "3.5.1"
@@ -534,7 +534,7 @@ lodash.get@4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -566,10 +566,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-njct@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/njct/-/njct-1.0.0.tgz#5a7d4abd038473edac138594cca80744f9492de8"
-
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -577,6 +573,10 @@ number-is-nan@^1.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/object-values/-/object-values-1.0.0.tgz#72af839630119e5b98c3b02bb8c27e3237158105"
 
 once@^1.3.0:
   version "1.4.0"
@@ -614,6 +614,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -676,15 +680,11 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve-from@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
-
-resolve-pkg@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pkg/-/resolve-pkg-1.0.0.tgz#e19a15e78aca2e124461dc92b2e3943ef93494d9"
+resolve@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
-    resolve-from "^2.0.0"
+    path-parse "^1.0.5"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -793,6 +793,10 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
 
+tslib@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -803,9 +807,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz#ef39cdea27abac0b500242d6726ab90e0c846631"
+typescript@^2.6.2:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 user-home@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This should resolve issues when the imported file isn't the package base (ie is a import of a JS file).

Upgraded to latest esm-export as well.