### PR TITLE
➖ Remove Typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ This package only activates if one of the following grammars/languages are being
 * [language-javascript](https://atom.io/packages/language-javascript)
 * [language-babel](https://atom.io/packages/language-babel)
 * [language-coffee-script](https://atom.io/packages/language-coffee-script)
-* [language-ts](https://atom.io/packages/language-ts)
-* [language-typescript-grammars-only](https://atom.io/packages/language-typescript-grammars-only)
-* [language-typescript](https://atom.io/packages/language-typescript)
-* [atom-typescript](https://atom.io/packages/atom-typescript)
+
+If you're using TypeScript, we suggest to use [atom-typescript](https://atom.io/packages/atom-typescript) or [ide-typescript](https://atom.io/packages/ide-typescript) packages, which are way better as it uses the TS-server. 
 
 If this package doesn't seem to be working, check that you are using one of these.
 If you want another grammar/language to be supported, please submit an issue.

--- a/package.json
+++ b/package.json
@@ -43,10 +43,6 @@
   "activationHooks": [
     "language-javascript:grammar-used",
     "language-babel:grammar-used",
-    "language-coffee-script:grammar-used",
-    "language-typescript:grammar-used",
-    "language-ts:grammar-used",
-    "language-typescript-grammars-only:grammar-used",
-    "atom-typescript:grammar-used"
+    "language-coffee-script:grammar-used"
   ]
 }

--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -14,17 +14,11 @@ const LINE_REGEXP = /(?:^|\s)require\(['"]|^import\s.+from\s+["']|^import\s+["']
 
 const SELECTOR = [
   '.source.js',
-  '.source.ts',
-  '.source.tsx',
   '.source.coffee'
 ];
 const SELECTOR_DISABLE = [
   '.source.js .comment',
-  '.source.js .keyword',
-  '.source.ts .comment',
-  '.source.ts .keyword',
-  '.source.tsx .comment',
-  '.source.tsx .keyword'
+  '.source.js .keyword'
 ];
 
 class CompletionProvider {


### PR DESCRIPTION
tl;dr: **Breaking Change!** Removing typescript support to not conflict with packages that most typescript users use by default.

Typescript servers handle module imports as well as autocomplete on class constructors or any usage in code.

Adding typescript grammar to do, causes unnecessary conflict.

As typescript users, having to use a typed language should utilize the benefit it brings as a IDE capable language.

Suggestions on using two different packages to support autocomplete of modules is mentioned.