### PR TITLE
Include selector for tree-sitter language scope

### DIFF
--- a/src/completion-provider.js
+++ b/src/completion-provider.js
@@ -14,11 +14,14 @@ const LINE_REGEXP = /(?:^|\s)require\(['"]|^import\s.+from\s+["']|^import\s+["']
 
 const SELECTOR = [
   '.source.js',
+  'javascript',
   '.source.coffee'
 ];
 const SELECTOR_DISABLE = [
   '.source.js .comment',
-  '.source.js .keyword'
+  'javascript comment',
+  '.source.js .keyword',
+  'javascript keyword'
 ];
 
 class CompletionProvider {


### PR DESCRIPTION
👋 Hello!

Atom recently introduced an alternative parsing engine called tree-sitter (atom/atom#16299). As a side effect of this, language grammar names will be changing. Tree-sitter grammars are currently behind a feature flag which is disabled by default.

I've added the new JavaScript grammar name to your completion provider's selector arrays to work with the new names, because I'm dogfooding tree-sitter for our team and I use this heavily 😄 

With this in place I'm able to autocomplete modules with tree-sitter enabled:

<img width="364" alt="screen shot 2018-05-21 at 9 16 15 am" src="https://user-images.githubusercontent.com/17565/40309507-c0bb37c4-5cd7-11e8-8d9c-5fe0ab2412e8.png">
