### PR TITLE
Exclude non-essential files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+/spec export-ignore
+/.circleci export-ignore
+/.editorconfig export-ignore
+/.eslintrc export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/CHANGELOG.md export-ignore
+/ISSUE_TEMPLATE.md export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download non-essential files which aren't necessary for the package to function. Such as files used for development (docs, screenshots, tests, .travis.yml, etc).

Happy Hacktoberfest!