### PR TITLE
Fix webpack aliased suggestions being filtered out

### DIFF
--- a/lib/lookups/module/index.js
+++ b/lib/lookups/module/index.js
@@ -11,7 +11,7 @@ const findBabelConfig = require('find-babel-config');
 const localLookup = new (require('./local'))(Readdir, PH.getModuleDir, PH.removeExtension, PH.extractPrefixFrom)
 const globalLookup = new (require('./global'))(Readdir, PH.getProjectPath, Path, localLookup);
 const webpackLookup = new (require('./webpack'))(_get, Path, localLookup,
-  LookupAlias, PH.getProjectPath);
+  LookupAlias, PH.getProjectPath, PH.extractPrefixFrom);
 const babelLookup = new (require('./babel'))(PH.getProjectPath, PH.extractPrefixFrom, Path, findBabelConfig, localLookup, LookupAlias);
 // END
 

--- a/lib/lookups/module/webpack.js
+++ b/lib/lookups/module/webpack.js
@@ -1,17 +1,18 @@
 const Promise = require('bluebird');
 
 class WebPackLookup {
-  constructor(lodashGet, path, lookupLocal, lookupAlias, getProjectPath) {
+  constructor(lodashGet, path, lookupLocal, lookupAlias, getProjectPath, extractPrefixFrom) {
     this._get = lodashGet;
     this.path = path;
     this.local = lookupLocal;
     this.lookupAlias = lookupAlias;
     this.getProjectPath = getProjectPath;
+    this.extractPrefixFrom = extractPrefixFrom;
   }
 
   isNeeded(_prefix, configs) { return configs.webpack === true; }
 
-  massagePrefix(prefix) { return prefix; }
+  massagePrefix(prefix) { return this.extractPrefixFrom(prefix); }
 
   getList(prefix, filePath, configs) {
     const projectPath = this.getProjectPath(filePath);

--- a/spec/module/webpack-spec.js
+++ b/spec/module/webpack-spec.js
@@ -1,12 +1,28 @@
 const { getProjectPathStub, fixturesBasePath: base, async, localLookupStub } = require('../spec-helper');
 // Use the fixtures folder as your test dummy
 const lookupAlias = require('../../lib/utils/lookup-alias');
+const { extractPrefixFrom } = require('../../lib/utils/path-helpers');
 
 describe('module lookup: webpack on webpack.config.js',() => {
   let subject, config = { vendors: ['node_modules'], webpackConfigFilename: 'webpack.config.alias.js' };
   beforeEach(() => {
     subject = new (require('../../lib/lookups/module/webpack'))
-      (require('lodash.get'), require('path'), localLookupStub, lookupAlias, getProjectPathStub);
+      (require('lodash.get'), require('path'), localLookupStub, lookupAlias, getProjectPathStub, extractPrefixFrom);
+  });
+  
+  describe('massage prefix', () => {
+    it('should remove relative pathing', () => {
+      const resultSingle = subject.massagePrefix('./test');
+      expect(resultSingle).toBe('test');
+
+      const resultDouble = subject.massagePrefix('../test');
+      expect(resultDouble).toBe('test');
+    });
+
+    it('should remove parent directory', () => {
+      const result = subject.massagePrefix('./parent/test');
+      expect(result).toBe('test');
+    });
   });
 
   describe('resolve.alias', () => {


### PR DESCRIPTION
Hi,

So I noticed that no suggestions show up when I try and import from a webpack alias. For example, given the following Webpack config:

```js
resolve: {
  alias: {
    "~": path.resolve(__dirname, "src")
  }
}
```

If I type `import App from "~/"` then I would expect to see the children of `src/`, but in fact I see nothing. It looks like the problem is that the suggestions are [being filtered](https://github.com/nkt/atom-autocomplete-modules/blob/master/lib/lookups/index.js#L25) based on `prefix`, but `prefix` doesn't match any results since they've been transformed by the alias.

So my solution is to copy the `massagePrefix` behaviour from `LocalLookup` into `WebpackLookup`, i.e. suggestions will only be matched on the last part of the path. I can't see any reason why this would be a problem, but hopefully someone more familiar with the codebase can confirm that.
